### PR TITLE
添加切换区服成功提示，优化UI大小以及操作

### DIFF
--- a/GenshinImpact_Lanucher/App.xaml
+++ b/GenshinImpact_Lanucher/App.xaml
@@ -1,25 +1,14 @@
 ﻿<Application x:Class="GenshinImpact_Lanucher.App"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:GenshinImpact_Lanucher"
-             StartupUri="MainWindow.xaml">
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:GenshinImpact_Lanucher"
+    StartupUri="MainWindow.xaml">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="pack://application:,,,/WPFUI;component/Styles/Theme/Dark.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/WPFUI;component/Styles/Theme/Light.xaml  " />
                 <ResourceDictionary Source="pack://application:,,,/WPFUI;component/Styles/WPFUI.xaml" />
             </ResourceDictionary.MergedDictionaries>
-
-            <!--
-                Here is an example of manually assigning the Segoe Fluent Icons font. It's dynamically caught by the library, so it should work fine.
-                Remember to do this assignment AFTER the WPFUI styles are loaded, otherwise the library will try to load the system font.
-            -->
-            <!-- <FontFamily x:Key="SegoeFluentIcons">pack://application:,,,/;component/Fonts/#Segoe Fluent Icons</FontFamily> -->
-
-            <!--
-                Here is an example of manually changing only one color
-            -->
-            <!-- <SolidColorBrush x:Key="UiBrushHyperlink" Color="#FFBBB711" /> -->
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/GenshinImpact_Lanucher/GenshinImpact_Lanucher.csproj
+++ b/GenshinImpact_Lanucher/GenshinImpact_Lanucher.csproj
@@ -88,7 +88,7 @@
     <ManifestKeyFile>GenshinImpact_Lanucher_TemporaryKey.pfx</ManifestKeyFile>
   </PropertyGroup>
   <PropertyGroup>
-    <SignManifests>true</SignManifests>
+    <SignManifests>false</SignManifests>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BasicFormatsForCore">
@@ -195,7 +195,6 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <None Include="GenshinImpact_Lanucher_TemporaryKey.pfx" />
     <None Include="Properties\app.manifest" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
@@ -208,11 +207,6 @@
   <ItemGroup>
     <PackageReference Include="Cake.Powershell">
       <Version>1.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="Costura.Fody">
-      <Version>5.8.0-alpha0098</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.TestPlatform.TestHost">
       <Version>17.1.0</Version>

--- a/GenshinImpact_Lanucher/MainWindow.xaml
+++ b/GenshinImpact_Lanucher/MainWindow.xaml
@@ -7,7 +7,8 @@
         mc:Ignorable="d"
         ResizeMode="NoResize"
         xmlns:wpfui="clr-namespace:WPFUI.Controls;assembly=WPFUI" 
-        xmlns:i="http://schemas.microsoft.com/xaml/behaviors" xmlns:pages="clr-namespace:GenshinImpact_Lanucher.Pages"
+        xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
+        xmlns:pages="clr-namespace:GenshinImpact_Lanucher.Pages"
         Title="MainWindow" Height="600" Width="1000"
         Style="{DynamicResource UiWindowNoResize}">
     <i:Interaction.Triggers>

--- a/GenshinImpact_Lanucher/Models/Launcher_Ini.cs
+++ b/GenshinImpact_Lanucher/Models/Launcher_Ini.cs
@@ -286,15 +286,39 @@ namespace GenshinImpact_Lanucher.Model
             {
                 if (Resource.BilibiliSDK() == true)
                 {
+                    (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Message = "区服已经切换成功啦！";
+                    (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Icon = WPFUI.Common.SymbolRegular.CheckmarkCircle24; //icon 参考https://hub.fastgit.xyz/microsoft/fluentui-system-icons/blob/master/icons_regular.md
+                    (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Title = "区服切换成B服";       //返回的信息标题
+                    (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Show();
                     WritePrivateProfileString("General", "cps", "bilibili", LauncherPath);
                     WritePrivateProfileString("General", "sub_channel", "0", LauncherPath);
                     WritePrivateProfileString("General", "channel", "14", LauncherPath);
                     return true;
+                }else if (Resource.BilibiliSDK() == false)            //严谨一点好
+                {
+                    (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Message = "旅行者似乎没有配置游戏路径呢";
+                    (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Icon = WPFUI.Common.SymbolRegular.ErrorCircle24;
+                    (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Title = "区服切换失败";
+                    (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Show();
+                    return false;
                 }
-                return false;
+                    return false;
             }
             else if (server == Server.官服)            //严谨一点好
             {
+                Launcher_Ini myini = new Launcher_Ini($@"{docpath}/GSIConfig/Config/LauncherConfig.ini");
+                if (myini.IniReadValue("MyLanucherConfig", "GamePath") == null || myini.IniReadValue("MyLanucherConfig", "GamePath").Equals(""))
+                {
+                    (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Message = "旅行者似乎没有配置游戏路径呢";
+                    (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Icon = WPFUI.Common.SymbolRegular.ErrorCircle24;
+                    (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Title = "区服切换失败";
+                    (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Show();
+                    return false;
+                }
+                (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Message = "区服已经切换成功啦！";
+                (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Icon = WPFUI.Common.SymbolRegular.CheckmarkCircle24;
+                (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Title = "区服切换成官服";
+                (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Show();
                 WritePrivateProfileString("General", "cps", "pcadbdpz", LauncherPath);
                 WritePrivateProfileString("General", "sub_channel", "1", LauncherPath);
                 WritePrivateProfileString("General", "channel", "1", LauncherPath);

--- a/GenshinImpact_Lanucher/Models/Resource.cs
+++ b/GenshinImpact_Lanucher/Models/Resource.cs
@@ -45,10 +45,6 @@ namespace GenshinImpact_Lanucher.Model
             Console.WriteLine(path);
             if (path == null || path.Equals("")) //检测路径是否为空，防止出现崩溃
             {
-                (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Message = "旅行者似乎没有配置游戏路径呢";
-                (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Icon = WPFUI.Common.SymbolRegular.ErrorCircle24;
-                (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Title = "区服切换失败";       //返回的错误列表
-                (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Show();
                 return false;
             }
             if (!File.Exists(path + @"\YuanShen_Data\Plugins\PCGameSDK.dll"))

--- a/GenshinImpact_Lanucher/Models/Resource.cs
+++ b/GenshinImpact_Lanucher/Models/Resource.cs
@@ -42,7 +42,6 @@ namespace GenshinImpact_Lanucher.Model
         {
             myini = new Launcher_Ini($@"{docpath}/GSIConfig/Config/LauncherConfig.ini");
             string path = myini.IniReadValue("MyLanucherConfig", "GamePath");
-            Console.WriteLine(path);
             if (path == null || path.Equals("")) //检测路径是否为空，防止出现崩溃
             {
                 return false;

--- a/GenshinImpact_Lanucher/Pages/DefaultGame.xaml
+++ b/GenshinImpact_Lanucher/Pages/DefaultGame.xaml
@@ -17,7 +17,7 @@
             <RowDefinition/>
         </Grid.RowDefinitions>
         <StackPanel Grid.Row="1" VerticalAlignment="Bottom" Orientation="Horizontal" HorizontalAlignment="Right">
-            <ToggleButton  Height="50" x:Name="Flage" Margin="0 0 10 10 " Padding="10"  FontSize="20">
+            <ToggleButton  Height="45" x:Name="Flage" Margin="0 0 10 10 " Padding="10"  FontSize="20">
                 <ToggleButton.Content>
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -25,7 +25,7 @@
                             <ColumnDefinition/>
                         </Grid.ColumnDefinitions>
                         <wpfui:SymbolIcon Symbol="Server24" HorizontalAlignment="Left"/>
-                        <TextBlock Text="服务器游戏" Grid.Column="1" Margin="10 0 0 0"/>
+                        <TextBlock Text="服务器游戏" Grid.Column="1" Margin="10 0 0 0" FontSize="15"/>
                     </Grid>
                 </ToggleButton.Content>
                 <i:Interaction.Triggers>
@@ -34,7 +34,7 @@
                     </i:EventTrigger>
                 </i:Interaction.Triggers>
             </ToggleButton>
-            <wpfui:Button  Grid.Row="1" HorizontalAlignment="Right" Icon="Play12" Content="开始游戏" VerticalAlignment="Bottom" Margin="0 0 10 10" Height="50" Padding="10" FontSize="20"
+            <wpfui:Button  Grid.Row="1" HorizontalAlignment="Right" Icon="Play12" Content="开始游戏" VerticalAlignment="Bottom" Margin="0 0 10 10" Height="45" Padding="10" FontSize="15"
                        Command="{Binding StartGame}"/>
         </StackPanel>
     </Grid>

--- a/GenshinImpact_Lanucher/Pages/SettingApp.xaml
+++ b/GenshinImpact_Lanucher/Pages/SettingApp.xaml
@@ -20,7 +20,7 @@
                     <Grid.RowDefinitions>
                         <RowDefinition/>
                         <RowDefinition/>
-                        <RowDefinition/> 
+                        <RowDefinition/>
                         <RowDefinition/>
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
@@ -114,7 +114,7 @@
                                 </i:EventTrigger>
                             </i:Interaction.Triggers>
                         </TextBox>
-                        
+
                     </StackPanel>
                     <StackPanel  Grid.Row="2" Margin="10 10 0 0"
                                 Orientation="Horizontal"
@@ -188,24 +188,21 @@
                             <ColumnDefinition/>
                             <ColumnDefinition Width="auto"/>
                         </Grid.ColumnDefinitions>
-                        <TextBox HorizontalAlignment="Stretch"
+                        <wpfui:TextBox Placeholder="例如: E:\Grasscutters\(目录下含有Grasscutters.jar类似文件)"
                                  Cursor="Hand"
                                  ToolTipService.ToolTip="本服务器要求本地游戏版本为2.6"
-                                 IsReadOnly="True"
                                  Height="40"
                                  Text="{Binding _ServerPath,Mode=TwoWay}">
-                            <i:Interaction.Triggers>
-                                <i:EventTrigger EventName="MouseDoubleClick">
-                                    <i:InvokeCommandAction Command="{Binding SelectServerPath}"/>
-                                </i:EventTrigger>
-                            </i:Interaction.Triggers>
-                        </TextBox>
-                        
+                        </wpfui:TextBox>
+                        <Button
+                            Grid.Column="1"
+                            Content="浏览" Padding="10" Margin="10,0,0,0" Command="{Binding SelectServerPath}" Cursor="Hand"/>
+
                     </Grid>
                 </Grid>
             </wpfui:CardExpander>
             <TextBlock Text="其他功能正在开发中o(*￣▽￣*)ブ" HorizontalAlignment="Center" Margin="0 10 0 0"/>
         </StackPanel>
-        
+
     </Grid>
 </Page>

--- a/GenshinImpact_Lanucher/Pages/SettingApp.xaml
+++ b/GenshinImpact_Lanucher/Pages/SettingApp.xaml
@@ -41,7 +41,6 @@
                     <StackPanel Margin="10 0 0 0" Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center"  >
                         <RadioButton Content="官服" GroupName="Server" 
                                      Margin="10 0 0 0"
-                                     FontSize="20"
                                      IsChecked="{Binding Server1,Mode=TwoWay}"
                                      x:Name="RadServer1"
                                       >
@@ -57,7 +56,6 @@
                         <RadioButton Content="B服" GroupName="Server" 
                                      Margin="10 0 0 0"
                                      HorizontalAlignment="Center"
-                                     FontSize="20"
                                      x:Name="RadServer2"
                                      IsChecked="{Binding Server2,Mode=TwoWay}">
                             <i:Interaction.Triggers>
@@ -81,7 +79,7 @@
                                 <ColumnDefinition/>
                                 <ColumnDefinition Width="auto"/>
                             </Grid.ColumnDefinitions>
-                            <TextBox HorizontalAlignment="Stretch" Text="{Binding StartArgs.GamePath}"/>
+                            <wpfui:TextBox Placeholder="例如: E:\Genshin Impact\Genshin Impact Game"  HorizontalAlignment="Stretch" Text="{Binding StartArgs.GamePath}"/>
                             <Button Grid.Row="1"
                                 Grid.Column="1"
                                 Content="浏览" Padding="10" Margin="10 0 0 0" Command="{Binding SelectGamePath}"/>

--- a/GenshinImpact_Lanucher/Pages/SettingApp.xaml
+++ b/GenshinImpact_Lanucher/Pages/SettingApp.xaml
@@ -1,4 +1,4 @@
-﻿<Page x:Class="GenshinImpact_Lanucher.Pages.SettingApp"
+<Page x:Class="GenshinImpact_Lanucher.Pages.SettingApp"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -189,7 +189,6 @@
                             <ColumnDefinition Width="auto"/>
                         </Grid.ColumnDefinitions>
                         <wpfui:TextBox Placeholder="例如: E:\Grasscutters\(目录下含有Grasscutters.jar类似文件)"
-                                 Cursor="Hand"
                                  ToolTipService.ToolTip="本服务器要求本地游戏版本为2.6"
                                  Height="40"
                                  Text="{Binding _ServerPath,Mode=TwoWay}">

--- a/GenshinImpact_Lanucher/ViewModels/DefaultGameVM.cs
+++ b/GenshinImpact_Lanucher/ViewModels/DefaultGameVM.cs
@@ -37,7 +37,7 @@ namespace GenshinImpact_Lanucher.ViewModels
             if (a == "1")
             {
                 (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Message = "从外部启动游戏成功！如果出现闪退请检查游戏文件夹";
-                (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Icon = WPFUI.Common.SymbolRegular.ErrorCircle24;
+                (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Icon = WPFUI.Common.SymbolRegular.CheckmarkCircle24;
                 (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Title = "游戏已经启动";       //返回的错误列表
                 (System.Windows.Application.Current.MainWindow as MainWindow).WindowTitler.Show();
             }


### PR DESCRIPTION
> 因为在我的VSblend中Costura.Fody会触发设计器故障，所以删除了Costura.Fody
> 因为似乎并未配置签名，所以删除了签名文件以及关闭了签名选项
> 因为似乎WPFUI中的主题出现问题，导致在白色界面中会出现深色主题的控件，虽然调整至了light.xaml，但是似乎还是无法解决此问题
> 因为似乎WPFUI中的主题出现问题，导致在Win11 beta 22616.1中无法显示Mica主题，此问题暂时无法解决
> 在点击服务器游戏后，按钮背景会从透明变成蓝色，但是字体与icon还是为黑色，虽然想修复，但是因为本人能力问题，暂且还无法找到修复方法

修改列表：

1. 添加了官服与b服切换成功的提示框，移动b服切换失败提示框至官b服切换的cs中（如图4）
2. 修改了设置界面中的区服切换的选项按钮的字体大小 20->14 （如图2）
3. 修改了主页面的两个按钮大小（不然看起来太大了wwww）（如图1）
4. 添加两个路径选择的提示文字 （如图2）
5. 将本地游戏文件夹的选择路径框修改成游戏文件夹的选择路径框 （如图2）
6. 修复切换b服后重新切换成官服但并未设置游戏路径时未弹出提示框（如图3）

![图片](https://user-images.githubusercontent.com/69132853/167750566-465c8a92-2dd0-4aaa-9cb4-f0b90afee908.png)
![图片](https://user-images.githubusercontent.com/69132853/167750619-94fd4438-4a55-4779-97b6-98f34ef5311c.png)
![图片](https://user-images.githubusercontent.com/69132853/167750846-a67a8532-80db-489a-a243-c55beb245542.png)
![图片](https://user-images.githubusercontent.com/69132853/167750978-3db0f105-8082-41e8-82fd-3a50c0154d97.png)


